### PR TITLE
Add html2text as requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ tr A-Z a-z < all.tokenized.txt > all.tokenized.txt.low
 - progressbar2
 - nltk
   - And, download tokenizers by `python -c "import nltk;nltk.download('punkt')"`
+- html2text
 
 
 ## Acknowledgement


### PR DESCRIPTION
epub2text requires html2text, which is not listed in current README.md.