### PR TITLE
Fix merging sentences in one paragraph

### DIFF
--- a/make_sentlines.py
+++ b/make_sentlines.py
@@ -8,22 +8,18 @@ file_dir = sys.argv[1]
 
 
 def convert_into_sentences(lines):
-    blank = 0
     stack = []
     sent_L = []
     n_sent = 0
     for chunk in lines:
         if not chunk.strip():
-            blank += 1
-            if blank >= 2:
-                if stack:
-                    sents = sent_tokenize(
-                        " ".join(stack).strip().replace('\n', ' '))
-                    sent_L.extend(sents)
-                    n_sent += len(sents)
-                    sent_L.append('\n')
-                    stack = []
-                blank = 0
+            if stack:
+                sents = sent_tokenize(
+                    " ".join(stack).strip().replace('\n', ' '))
+                sent_L.extend(sents)
+                n_sent += len(sents)
+                sent_L.append('\n')
+                stack = []
             continue
         stack.append(chunk.strip())
 


### PR DESCRIPTION
This PR simply merges sentences in stack whenever it met an empty line.
I am not sure why `blank` was necessary at the first place, so let't discuss about it if I'm missing some thing here.

Consider one example from starting section of `out_txts/100021__three-plays.txt`.
Current implementation output:
```
Three Plays Published by Mike Suttons at Smashwords Copyright 2011 Mike Sutton ISBN 978-1-4659-8486-9 Tripping on Nothing
```

It obviously merged the paragraph title `Tripping on Nothing` into stack incorrectly.
With this PR, output is:
```
Three Plays Published by Mike Suttons at Smashwords Copyright 2011 Mike Sutton ISBN 978-1-4659-8486-9


Tripping on Nothing
```