### PR TITLE
add strip for genre scraping

### DIFF
--- a/download_list.py
+++ b/download_list.py
@@ -135,7 +135,7 @@ def main():
             # get genres
             genre_txts = soup.find_all(class_="category")
             if genre_txts:
-                genres = [g.text.replace('\u00a0\u00bb\u00a0', '\t')
+                genres = [g.text.replace('\u00a0\u00bb\u00a0', '\t').strip()
                           for g in genre_txts]
             elif 'genres' in REQUIRED:
                 sys.stderr.write('Failed: genre {}\n'.format(b_url))


### PR DESCRIPTION
It was dirty. I added strip.

```
"genres": ["\n                            Category: Fiction \u00bb Mystery & detective \u00bb Women Sleuths ", "\n                            Category: Fiction \u00bb Fantasy \u00bb Paranormal "]
```
will be
```
"genres": ["Category: Fiction \u00bb Mystery & detective \u00bb Women Sleuths", "Category: Fiction \u00bb Fantasy \u00bb Paranormal"]
```